### PR TITLE
Center Zoom view on Meetings page

### DIFF
--- a/src/components/ZoomComponentViewEnhanced.tsx
+++ b/src/components/ZoomComponentViewEnhanced.tsx
@@ -176,10 +176,10 @@ export function ZoomComponentViewEnhanced({
 
   // Enhanced container with session monitoring
   return (
-    <div className="w-full h-full">
-      <div 
+    <div className="flex items-center justify-center w-full h-full">
+      <div
         id="meetingSDKElement"
-        className="w-full h-full"
+        className="w-[960px] h-[540px] max-w-full max-h-full"
       />
     </div>
   );

--- a/src/hooks/useZoomSDKEnhanced.tsx
+++ b/src/hooks/useZoomSDKEnhanced.tsx
@@ -115,7 +115,8 @@ export function useZoomSDKEnhanced({ onReady, onError }: UseZoomSDKProps = {}) {
         debug: true,
         zoomAppRoot: meetingSDKElement,
         assetPath: assetPath,
-        language: 'en-US'
+        language: 'en-US',
+        videoDrag: false
       };
 
       console.log('🔄 [SDK-ENHANCED] Calling client.init()...');


### PR DESCRIPTION
## Summary
- style Zoom component view to be centered at 960×540
- disable video dragging in `useZoomSDKEnhanced`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f3f1adc6c832aa737760b6cdf8278