### PR TITLE
Improve Zoom cleanup and view

### DIFF
--- a/src/components/ZoomComponentView.tsx
+++ b/src/components/ZoomComponentView.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
-import { useAuth } from '@/context/AuthContext';
-import { useZoomSDK } from '@/hooks/useZoomSDK';
-import { supabase } from '@/integrations/supabase/client';
+import { lazy, Suspense } from 'react';
+
+const ZoomComponentViewEnhanced = lazy(() => import('./ZoomComponentViewEnhanced'));
 
 interface ZoomComponentViewProps {
   meetingNumber: string;
@@ -13,29 +12,12 @@ interface ZoomComponentViewProps {
   onMeetingLeft?: () => void;
 }
 
-export function ZoomComponentView({
-  meetingNumber,
-  meetingPassword,
-  userName: providedUserName,
-  role = 0,
-  onMeetingJoined,
-  onMeetingError,
-  onMeetingLeft
-}: ZoomComponentViewProps) {
-  // Redirect to enhanced version
+export function ZoomComponentView(props: ZoomComponentViewProps) {
   console.log('🔄 [COMPONENT-VIEW] Redirecting to enhanced version');
-  
-  const ZoomComponentViewEnhanced = require('./ZoomComponentViewEnhanced').ZoomComponentViewEnhanced;
-  
+
   return (
-    <ZoomComponentViewEnhanced
-      meetingNumber={meetingNumber}
-      meetingPassword={meetingPassword}
-      userName={providedUserName}
-      role={role}
-      onMeetingJoined={onMeetingJoined}
-      onMeetingError={onMeetingError}
-      onMeetingLeft={onMeetingLeft}
-    />
+    <Suspense fallback={<div className="flex items-center justify-center w-full h-full">Loading...</div>}>
+      <ZoomComponentViewEnhanced {...props} />
+    </Suspense>
   );
 }

--- a/src/components/ZoomComponentViewEnhanced.tsx
+++ b/src/components/ZoomComponentViewEnhanced.tsx
@@ -176,10 +176,10 @@ export function ZoomComponentViewEnhanced({
 
   // Enhanced container with session monitoring
   return (
-    <div className="w-full h-full">
-      <div 
+    <div className="flex items-center justify-center w-full h-full">
+      <div
         id="meetingSDKElement"
-        className="w-full h-full"
+        className="w-[960px] h-[540px] max-w-full max-h-full"
       />
     </div>
   );

--- a/src/context/ZoomSessionContext.tsx
+++ b/src/context/ZoomSessionContext.tsx
@@ -89,11 +89,20 @@ export function ZoomSessionProvider({ children }: { children: React.ReactNode })
       }
     };
 
+    const handlePageHide = () => {
+      if (isSessionActive()) {
+        console.log('📴 [SESSION-MANAGER] Pagehide detected, cleaning up session');
+        forceLeaveSession();
+      }
+    };
+
     window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('pagehide', handlePageHide);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('pagehide', handlePageHide);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [forceLeaveSession, isSessionActive]);

--- a/src/hooks/useMeetingExit.tsx
+++ b/src/hooks/useMeetingExit.tsx
@@ -72,18 +72,27 @@ export function useMeetingExit({
     }
   }, [checkMeetingStatus, leaveMeeting]);
 
+  const handlePageHide = useCallback(() => {
+    if (checkMeetingStatus()) {
+      console.log('📴 [MEETING-EXIT] Pagehide detected, leaving meeting');
+      leaveMeeting();
+    }
+  }, [checkMeetingStatus, leaveMeeting]);
+
   // Set up event listeners
   useEffect(() => {
     if (isJoined) {
       window.addEventListener('beforeunload', handleBeforeUnload);
+      window.addEventListener('pagehide', handlePageHide);
       document.addEventListener('visibilitychange', handleVisibilityChange);
 
       return () => {
         window.removeEventListener('beforeunload', handleBeforeUnload);
+        window.removeEventListener('pagehide', handlePageHide);
         document.removeEventListener('visibilitychange', handleVisibilityChange);
       };
     }
-  }, [isJoined, handleBeforeUnload, handleVisibilityChange]);
+  }, [isJoined, handleBeforeUnload, handleVisibilityChange, handlePageHide]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/hooks/useZoomSDKEnhanced.tsx
+++ b/src/hooks/useZoomSDKEnhanced.tsx
@@ -115,7 +115,8 @@ export function useZoomSDKEnhanced({ onReady, onError }: UseZoomSDKProps = {}) {
         debug: true,
         zoomAppRoot: meetingSDKElement,
         assetPath: assetPath,
-        language: 'en-US'
+        language: 'en-US',
+        videoDrag: false
       };
 
       console.log('🔄 [SDK-ENHANCED] Calling client.init()...');

--- a/src/index.css
+++ b/src/index.css
@@ -100,3 +100,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Zoom component overrides */
+#meetingSDKElement { @apply flex items-center justify-center; }
+#meetingSDKElement .react-draggable,
+#meetingSDKElement .react-resizable { position: static !important; transform: none !important; width: 100% !important; height: 100% !important; }
+#meetingSDKElement .react-resizable-handle { display: none !important; }
+


### PR DESCRIPTION
## Summary
- dynamically import ZoomComponentViewEnhanced
- add `pagehide` handlers in Zoom session cleanup hooks
- force non-draggable Zoom layout with custom CSS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f3f1adc6c832aa737760b6cdf8278